### PR TITLE
chore: update alpine to 3.18, replace sprintf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 AS build
+FROM alpine:3.18 AS build
 
 RUN apk add --no-cache msgpack-c ncurses-libs libevent libexecinfo openssl zlib
 
@@ -31,7 +31,7 @@ RUN set -ex; \
 	make install
 
 ### Minimal run-time image
-FROM alpine:3.16
+FROM alpine:3.18
 
 RUN apk add --no-cache \
 	bash \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.18
 
 RUN apk add --no-cache msgpack-c ncurses-libs libevent libexecinfo openssl zlib
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # configure.ac
 
-AC_INIT(tmate-ssh-server, 2.3.0)
+AC_INIT([tmate-ssh-server],[2.3.0])
 
 AM_SILENT_RULES([yes])
 AC_CONFIG_AUX_DIR(etc)
@@ -26,7 +26,7 @@ test "$sysconfdir" = '${prefix}/etc' && sysconfdir=/etc
 
 AC_ARG_ENABLE(
 	devenv,
-	AC_HELP_STRING(--enable-devenv, "dev env (port 2200, no random tokens)"),
+	AS_HELP_STRING([--enable-devenv],["dev env (port 2200, no random tokens)"]),
 	found_devenv=$enable_devenv
 )
 AM_CONDITIONAL(IS_DEVENV, test "x$found_devenv" = xyes)
@@ -35,7 +35,7 @@ AM_CONDITIONAL(IS_DEVENV, test "x$found_devenv" = xyes)
 found_debug=yes
 AC_ARG_ENABLE(
 	debug,
-	AC_HELP_STRING(--enable-debug, enable debug build flags),
+	AS_HELP_STRING([--enable-debug],[enable debug build flags]),
 	found_debug=$enable_debug
 )
 AM_CONDITIONAL(IS_DEBUG, test "x$found_debug" = xyes)
@@ -43,7 +43,7 @@ AM_CONDITIONAL(IS_DEBUG, test "x$found_debug" = xyes)
 # Is this --enable-coverage?
 AC_ARG_ENABLE(
 	coverage,
-	AC_HELP_STRING(--enable-coverage, enable coverage build flags),
+	AS_HELP_STRING([--enable-coverage],[enable coverage build flags]),
 	found_coverage=$enable_coverage
 )
 AM_CONDITIONAL(IS_COVERAGE, test "x$found_coverage" = xyes)
@@ -51,7 +51,7 @@ AM_CONDITIONAL(IS_COVERAGE, test "x$found_coverage" = xyes)
 # Is this a static build?
 AC_ARG_ENABLE(
 	static,
-	AC_HELP_STRING(--enable-static, create a static build),
+	AS_HELP_STRING([--enable-static],[create a static build]),
 	found_static=$enable_static
 )
 if test "x$found_static" = xyes; then
@@ -224,31 +224,23 @@ AC_CHECK_FUNCS([setresuid setresgid setreuid setregid])
 
 # Check for b64_ntop.
 AC_MSG_CHECKING(for b64_ntop)
-AC_TRY_LINK(
-	[
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 		#include <sys/types.h>
 		#include <netinet/in.h>
 		#include <resolv.h>
-	],
-	[b64_ntop(NULL, 0, NULL, 0);],
-	found_b64_ntop=yes,
-	found_b64_ntop=no
-)
+	]], [[b64_ntop(NULL, 0, NULL, 0);]])],[found_b64_ntop=yes],[found_b64_ntop=no
+])
 if test "x$found_b64_ntop" = xno; then
 	AC_MSG_RESULT(no)
 
 	AC_MSG_CHECKING(for b64_ntop with -lresolv)
 	LIBS="$LIBS -lresolv"
-	AC_TRY_LINK(
-		[
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 			#include <sys/types.h>
 			#include <netinet/in.h>
 			#include <resolv.h>
-		],
-		[b64_ntop(NULL, 0, NULL, 0);],
-		found_b64_ntop=yes,
-		found_b64_ntop=no
-	)
+		]], [[b64_ntop(NULL, 0, NULL, 0);]])],[found_b64_ntop=yes],[found_b64_ntop=no
+	])
 	if test "x$found_b64_ntop" = xno; then
 		AC_MSG_RESULT(no)
 	fi
@@ -598,4 +590,5 @@ AM_CONDITIONAL(IS_HPUX, test "x$PLATFORM" = xhpux)
 AM_CONDITIONAL(IS_UNKNOWN, test "x$PLATFORM" = xunknown)
 
 # autoconf should create a Makefile.
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/tmate-ssh-server.c
+++ b/tmate-ssh-server.c
@@ -383,7 +383,7 @@ static void ssh_import_key(ssh_bind bind, const char *keys_dir, const char *name
 	char path[PATH_MAX];
 	ssh_key key = NULL;
 
-	sprintf(path, "%s/%s", keys_dir, name);
+	snprintf(path, sizeof(path), "%s/%s", keys_dir, name);
 
 	if (access(path, F_OK) < 0)
 		return;


### PR DESCRIPTION
Bump alpine to 3.18 (current 2023-06-03)
Replace sprintf with snprintf to avoid CWE-122 (https://cwe.mitre.org/data/definitions/122.html)